### PR TITLE
Fixed a bug with IE where host was blank with relative URLs

### DIFF
--- a/local-links.js
+++ b/local-links.js
@@ -25,9 +25,9 @@ function normalizeLeadingSlash (pathname) {
   return pathname
 }
 
-function isRelativeUrl(href) {
-    var r = /^https?:\/\/|^\/\//i;
-    return !r.test(href);
+function isRelativeUrl (href) {
+  var r = /^https?:\/\/|^\/\//i
+  return !r.test(href)
 }
 
 function isSecondaryButton (event) {
@@ -85,7 +85,7 @@ function isLocal (event, anchor, lookForHash) {
     'href' in anchor.attributes &&
     'value' in anchor.attributes.href &&
     isRelativeUrl(anchor.attributes.href.value)) {
-        aHost = wHost;
+    aHost = wHost
   }
 
   // Some browsers (Chrome 36) return an empty string for anchor.hash

--- a/local-links.js
+++ b/local-links.js
@@ -25,6 +25,11 @@ function normalizeLeadingSlash (pathname) {
   return pathname
 }
 
+function isRelativeUrl(href) {
+    var r = /^https?:\/\/|^\/\//i;
+    return !r.test(href);
+}
+
 function isSecondaryButton (event) {
   return (typeof event === 'object') && ('button' in event) && event.button !== 0
 }
@@ -75,7 +80,13 @@ function isLocal (event, anchor, lookForHash) {
   // In some cases, IE will have a blank host property when the href
   // is a relative URL. We can check for relativeness via the achor's
   // href attribute and then set the anchor's host to the window's host.
-  if (aHost === '' && anchor.attributes.href.value.match(/^\//)) aHost = wHost;
+  if (aHost === '' &&
+    'attributes' in anchor &&
+    'href' in anchor.attributes &&
+    'value' in anchor.attributes.href &&
+    isRelativeUrl(anchor.attributes.href.value)) {
+        aHost = wHost;
+  }
 
   // Some browsers (Chrome 36) return an empty string for anchor.hash
   // even when href="#", so we also check the href

--- a/local-links.js
+++ b/local-links.js
@@ -72,6 +72,11 @@ function isLocal (event, anchor, lookForHash) {
   var wHost = window.location.host
   var wPort = window.location.port
 
+  // In some cases, IE will have a blank host property when the href
+  // is a relative URL. We can check for relativeness via the achor's
+  // href attribute and then set the anchor's host to the window's host.
+  if (aHost === '' && anchor.attributes.href.value.match(/^\//)) aHost = wHost;
+
   // Some browsers (Chrome 36) return an empty string for anchor.hash
   // even when href="#", so we also check the href
   var aHash = anchor.hash || (anchor.href.indexOf('#') > -1 ? '#' + anchor.href.split('#')[1] : null)


### PR DESCRIPTION
In some cases, IE will have a blank `host` property when the `href` is a relative URL. We can check for "relativeness" via the achor's original `href` attribute (`a.attributes.href.value`) and then set the anchor's host to the window's host if the `href` doesn't matches the following regex: `/^https?:\/\/|^\/\//i`
